### PR TITLE
Handle errors that occur outside of Angular Zone

### DIFF
--- a/src/app/core/errors/global-error-handler.ts
+++ b/src/app/core/errors/global-error-handler.ts
@@ -1,14 +1,17 @@
-import { ErrorHandler, Injectable } from "@angular/core";
+import { ErrorHandler, Injectable, NgZone } from "@angular/core";
 import { ErrorDialogService } from "../../shared/errors/error-dialog.service";
 
 @Injectable()
 export class GlobalErrorHandler implements ErrorHandler {
-  constructor(private errorDialogService: ErrorDialogService) {}
+  constructor(private errorDialogService: ErrorDialogService, private zone: NgZone) {}
 
   handleError(error: Error) {
-    this.errorDialogService.openDialog(
-      error.message || "Undefined client error"
-    );
+
+    this.zone.run(() =>
+      this.errorDialogService.openDialog(
+        error.message || "Undefined client error"
+    ));
+
     console.error("Error from global error handler", error);
   }
 }


### PR DESCRIPTION
Fixes an issue where it is not possible to close dialog if error was thrown outside of the Angular Zone. 

For instance errors thrown in ngOnInit occur outside of the Angular Zone.

I considered adding an ngOnInit method to the AppComponent however it might be confusing for users to get an exception when the application is launched.

I have found this repository and the medium article really useful. I have opened this pull request because I would be interested in some feedback.
